### PR TITLE
Set visibility of notifications to public

### DIFF
--- a/app/src/main/java/de/moekadu/metronome/PlayerNotification.kt
+++ b/app/src/main/java/de/moekadu/metronome/PlayerNotification.kt
@@ -58,6 +58,7 @@ class PlayerNotification(val context: PlayerService) {
                 .setContentIntent(launchAct)
                 .setStyle(NotificationCompat.DecoratedCustomViewStyle())
                 .setCustomContentView(notificationView)
+        setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
     }
 
     private val notificationStateID = 3214


### PR DESCRIPTION
With the setting to hide sensitive content on the lockscreen the controls are not accessible on the lockscreen. 
I don't think the content of this app are sensitive and thus can be always shown. With this change the controls will always be shown.

Relevant doc: https://developer.android.com/training/notify-user/build-notification#lockscreenNotification

Zipped debug app with the changes: [app-debug.zip](https://github.com/thetwom/toc2/files/5252210/app-debug.zip)
